### PR TITLE
Refactored default configuration by adding unique placeholcers

### DIFF
--- a/config.default.yml
+++ b/config.default.yml
@@ -1,16 +1,22 @@
 server:
-    baseurl: http://localhost:5000
+    # E.g.: http://localhost:5000
+    baseurl: CA_WEBCLIENT_HTTP_URL
     ip: 0.0.0.0
     port: 5000
 
 apiserver:
-    hostname: ca.adito.dev
+    # E.g.: ca.adito.dev
+    hostname: CA_API_SERVER_URL
     port: 8080
     publicport: 8080
     tls: false
 
 csr_defaults:
-    country: DE
-    state: Bavaria
-    locality: Geisenhausen
-    organization: ADITO Software GmbH
+    # E.g.: DE
+    country: COUNTRY_CODE
+    # E.g.: Bavaria
+    state: STATE_NAME
+    # E.g.: Geisenhausen
+    locality: LOCALITY_NAME
+    # E.g.: ADITO Software GmbH
+    organization: ORGANIZATION_NAME


### PR DESCRIPTION
Hi there,

I refactored the default values to unique placeholders in order to make the default configuration updatable by a shell script. This change is required for example `sed` commands, which search and replace certain configuration values. This could be used for example inside Docker entrypoint script:

```bash
  sed -e "s/CA_WEBCLIENT_HTTP_URL/$CA_WEBCLIENT_HTTP_URL/" config/config.yml > config/config.yml.tmp && mv config/config.yml.tmp config/config.yml
  sed -e "s/CA_API_SERVER_URL/$CA_API_SERVER_URL/" config/config.yml > config/config.yml.tmp && mv config/config.yml.tmp config/config.yml
  sed -e "s/COUNTRY_CODE/$COUNTRY_CODE/" config/config.yml > config/config.yml.tmp && mv config/config.yml.tmp config/config.yml
  sed -e "s/STATE_NAME/$STATE_NAME/" config/config.yml > config/config.yml.tmp && mv config/config.yml.tmp config/config.yml
  sed -e "s/LOCALITY_NAME/$LOCALITY_NAME/" config/config.yml > config/config.yml.tmp && mv config/config.yml.tmp config/config.yml
  sed -e "s/ORGANIZATION_NAME/$ORGANIZATION_NAME/" config/config.yml > config/config.yml.tmp && mv config/config.yml.tmp config/config.yml
```

Using the same way of making the default values configurable was not fully possible until now, because some values weren't unique. E.g.: https://github.com/aditosoftware/nodepki/blob/54ed31d684592f17b5e7c9966d5b67ae6e5a661e/config.default.yml#L22

Would be nice to see this PR merged into the official nodepki Github repository. Any feedback is welcome.

Thanks.

Regards,
Philip